### PR TITLE
Normative: Permit arrow functions in pipeline

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -35,6 +35,8 @@ contributors: Daniel Ehrenberg
       PipelineExpression[In, Yield, Await] :
         LogicalORExpression[?In, ?Yield, ?Await]
         PipelineExpression[?In, ?Yield, ?Await] `|>` LogicalORExpression[?In, ?Yield, ?Await]
+        PipelineExpression[?In, ?Yield, ?Await] `|>` ArrowFunction[?In, ?Yield, ?Await]
+        PipelineExpression[?In, ?Yield, ?Await] `|>` AsyncArrowFunction[?In, ?Yield, ?Await]
     </ins>
   </emu-grammar>
 </emu-clause>


### PR DESCRIPTION
Putting AssignmentExpression in the right side of a pipeline would
create ambiguities; this PR just permits arrow functions specifically.

Addresses #60 . cc @jridgewell