### PR TITLE
Spec `|> await`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36,7 +36,7 @@ contributors: Daniel Ehrenberg
         LogicalORExpression[?In, ?Yield, ?Await]
         [~Await] PipelineExpression[?In, ?Yield, ?Await] `|>` LogicalORExpression[?In, ?Yield, ?Await]
         [+Await] PipelineExpression[?In, ?Yield, ?Await] `|>` [lookahead &lt;! {`await`}] LogicalORExpression[?In, ?Yield, ?Await]
-        [+Await] PipelineExpression[?In, ?Yield, ?Await] `|>` `await` LogicalORExpression[?In, ?Yield, ?Await]
+        [+Await] PipelineExpression[?In, ?Yield, ?Await] `|>` `await`
     </ins>
   </emu-grammar>
 </emu-clause>
@@ -81,9 +81,10 @@ contributors: Daniel Ehrenberg
         1. Let _result_ be the result of PipelineEvaluate for |PipelineExpression| and |LogicalORExpression|.
         1. Return _result_.
     </emu-alg>
-    <emu-grammar>PipelineExpression : PipelineExpression `|>` `await` LogicalORExpression</emu-grammar>
+    <emu-grammar>PipelineExpression : PipelineExpression `|>` `await`</emu-grammar>
     <emu-alg>
-        1. Let _result_ be the result of PipelineEvaluate for |PipelineExpression| and |LogicalORExpression|.
+        1. Let _argRef_ be the result of evaluating |PipelineExpression|.
+        1. Let _result_ be ? GetValue(_argRef_).
         1. Return ? AsyncFunctionAwait(_result_).
     </emu-alg>
     <emu-grammar>PipelineExpression : LogicalORExpression</emu-grammar>


### PR DESCRIPTION
This specifies the third of the options [here](https://github.com/tc39/proposal-pipeline-operator/issues/83#issuecomment-359101924) (I think).

I believe the inclusion of `GetValue` actually is observable because it means the running execution context is not suspended if the LHS is an abrupt completion, which is as I'd expect.

I'd be happier if we could prevent

```js
a |> await
b
```
from parsing as
```js
(a |> await);
(b);
```

(instead having it just be an error), but I can't see good way of doing that off the top of my head. The reason I want this is because it amounts to a "phantom" NoLineTerminatorHere restriction in `AwaitExpression`s which only applies in pipelines, which I don't really like.