### PR TITLE
Remove await from current minimal proposal spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,30 +94,7 @@ As you can see, because the pipe operator always pipes a single result value, it
 
 ### Use of `await`
 
-The pipeline operator allows the result of a `Promise`-returning function to be `await`ed as follows:
-
-
-```js
-x |> await f
-```
-
-which is the equivalent of
-
-```js
-await f(x)
-```
-
-This is to allow you to `await` the result of an asynchronous function and pass it to the next function from within a function pipeline, as follows:
-
-```js
-const userAge = userId |> await fetchUserById |> getAgeFromUser
-```
-
-which is the equivalent of
-
-```js
-const userAge = getAgeFromUser(await fetchUserById(userId))
-```
+The current minimal proposal makes `|> await f` an early error, so there is no support currently for `await` in the pipeline. Each proposal has a different solution to `await` in a pipeline, so support is planned. Please see the respective proposals for their solutions.
 
 ### Usage with `?` partial application syntax
 

--- a/spec.html
+++ b/spec.html
@@ -36,7 +36,6 @@ contributors: Daniel Ehrenberg
         LogicalORExpression[?In, ?Yield, ?Await]
         [~Await] PipelineExpression[?In, ?Yield, ?Await] `|>` LogicalORExpression[?In, ?Yield, ?Await]
         [+Await] PipelineExpression[?In, ?Yield, ?Await] `|>` [lookahead &lt;! {`await`}] LogicalORExpression[?In, ?Yield, ?Await]
-        [+Await] PipelineExpression[?In, ?Yield, ?Await] `|>` `await` LogicalORExpression[?In, ?Yield, ?Await]
     </ins>
   </emu-grammar>
 </emu-clause>
@@ -80,11 +79,6 @@ contributors: Daniel Ehrenberg
     <emu-alg>
         1. Let _result_ be the result of PipelineEvaluate for |PipelineExpression| and |LogicalORExpression|.
         1. Return _result_.
-    </emu-alg>
-    <emu-grammar>PipelineExpression : PipelineExpression `|>` `await` LogicalORExpression</emu-grammar>
-    <emu-alg>
-        1. Let _result_ be the result of PipelineEvaluate for |PipelineExpression| and |LogicalORExpression|.
-        1. Return ? AsyncFunctionAwait(_result_).
     </emu-alg>
     <emu-grammar>PipelineExpression : LogicalORExpression</emu-grammar>
     <emu-alg>


### PR DESCRIPTION
I just removed what enabled it. I think this is all thats needed on the spec side, unless there should be some explicit indication of a `SyntaxError` here?