### PR TITLE
Replace "_" with more explicit naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ let person = { score: 25 };
 
 let newScore = person.score
   |> double
-  |> (_ => add(7, _))
-  |> (_ => boundScore(0, 100, _));
+  |> (score => add(7, score))
+  |> (score => boundScore(0, 100, score));
 
 newScore //=> 57
 
@@ -191,12 +191,12 @@ Although the pipe operator operates well with functions that don't use `this`, i
 import Lazy from 'lazy.js'
 
 getAllPlayers()
-  .filter( p => p.score > 100 )
+  .filter( player => player.score > 100 )
   .sort()
-|> (_ => Lazy(_)
-  .map( p => p.name )
+|> (players => Lazy(players)
+  .map( player => player.name )
   .take(5))
-|> (_ => renderLeaderboard('#my-div', _));
+|> (players => renderLeaderboard('#my-div', players));
 ```
 
 ### Mixins

--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ newScore //=> 57
 // As opposed to: let newScore = boundScore( 0, 100, add(7, double(person.score)) )
 ```
 
-*Note: The use of underscore `_` is not required; it's just an arrow function, so you can use any parameter name you like.*
-
 As you can see, because the pipe operator always pipes a single result value, it plays very nicely with the single-argument arrow function syntax. Also, because the pipe operator's semantics are pure and simple, it could be possible for JavaScript engines to optimize away the arrow function.
 
 ### Use of `await`


### PR DESCRIPTION
Just a little nit.

The `_` is sometimes used as a denote a discarded value as it is not semantic and does not represent the value it is holding.

I've just replaced the `_` with explicit names from the examples hoping to slightly improve readability.