### PR TITLE
Replace links to smart pipes with Hack pipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This proposal introduces a new operator `|>` similar to
 Those proposals are as follows:
 
 * **F# Pipes**: [**Explainer**](https://github.com/valtech-nyc/proposal-fsharp-pipelines/blob/master/README.md) + [**Specification**](https://valtech-nyc.github.io/proposal-fsharp-pipelines/)
-* **Hack Pipes**: [**Explainer**](https://github.com/js-choi/proposal-hack-pipes/blob/master/readme.md) + [**Specification**](https://jschoi.org/21/es-hack-pipes/)
+* **Hack Pipes**: [**Explainer**](https://github.com/js-choi/proposal-hack-pipes/blob/master/README.md) + [**Specification**](https://jschoi.org/21/es-hack-pipes/)
 
 [Babel plugins](https://github.com/tc39/proposal-pipeline-operator/issues/89#issuecomment-363853394) for both are already underway to gather feedback.
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ This proposal introduces a new operator `|>` similar to
 
 Those proposals are as follows:
 
-* **F# Pipelines**: [**Explainer**](https://github.com/valtech-nyc/proposal-fsharp-pipelines/blob/master/README.md) + [**Specification**](https://valtech-nyc.github.io/proposal-fsharp-pipelines/)
-* **Smart Pipelines**: [**Explainer**](https://github.com/js-choi/proposal-smart-pipelines/blob/master/readme.md) + [**Specification**](https://jschoi.org/18/es-smart-pipelines/spec)
+* **F# Pipes**: [**Explainer**](https://github.com/valtech-nyc/proposal-fsharp-pipelines/blob/master/README.md) + [**Specification**](https://valtech-nyc.github.io/proposal-fsharp-pipelines/)
+* **Hack Pipes**: [**Explainer**](https://github.com/js-choi/proposal-hack-pipes/blob/master/readme.md) + [**Specification**](https://jschoi.org/21/es-hack-pipes/)
 
 [Babel plugins](https://github.com/tc39/proposal-pipeline-operator/issues/89#issuecomment-363853394) for both are already underway to gather feedback.
 


### PR DESCRIPTION
After talking more with @TabAtkins and @littledan, we’ve decided to archive the smart-mix pipes proposal in favor of a simpler Hack-pipes proposal. The latter is a subset of the former.