### PR TITLE
Add arguments for why pipelines are better than mutable temporary variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,9 +263,9 @@ function double(x) { return x * 2; }
 function three() { return 3; }
 
 let _ = one(); // _ is now 1
-    _ = double($); // _ is now 2
-    _ = Promise.resolve().then(() => console.log($)); // _ is now a promise, that's meant to log 2
-    _ = three($); // _ is now 3
+    _ = double(_); // _ is now 2
+    _ = Promise.resolve().then(() => console.log(_)); // _ is now a promise, that's meant to log 2
+    _ = three(_); // _ is now 3
 ```
 
 This issue wouldn't happen in a pipeline, due to scoping of the placeholder token:

--- a/README.md
+++ b/README.md
@@ -292,26 +292,49 @@ Another benefit of pipelines over sequences of assignment statements (with mutab
 
 <details>
 <summary>Examples</summary>
+  
+<table>
+<thead>
+  <td>Pipelines</td>
+  <td>Temporary Variables</td>
+</thead>
+<tbody>
+<tr>
+<td>
 
 ```js
-// with pipelines
-const numberedList = list |> ^.map((each, i) => `${i + 1} - ${each}`) |> ^.join('\n')
+const numberedList = list
+  |> ^.map((each, i) => `${i + 1} - ${each}`)
+  |> ^.join('\n')
+```
 
-// with temporary variables
+</td>
+<td>
+
+```js
 let _ = list
     _ = _.map((each, i) => `${i + 1} - ${each}`)
     _ = _.join('\n')
 const numberedList = _
 ```
+
+</td>
+</tr>
+<tr>
+<td>
+
 ```js
-// with pipelines
 const envVarFormat = (vars) =>
   Object.keys(vars)
   |> ^.map(var => `${var}=${vars[var]}`)
   |> ^.join(' ')
   |> chalk.dim(^, 'node', args.join(' '))
+```
 
-// with temporary variables
+</td>
+<td>
+
+```js
 const envVarFormat = (vars) => {
   let _ = Object.keys(vars)
       _ = _.map(var => `${var}=${vars[var]}`)
@@ -320,8 +343,13 @@ const envVarFormat = (vars) => {
   return _
 }
 ```
+
+</td>
+</tr>
+<tr>
+<td>
+
 ```jsx
-// with pipelines
 return (
   <ul>
     {
@@ -334,8 +362,12 @@ return (
     }
   </ul>
 )
+```
 
-// with temporary variables
+</td>
+<td>
+  
+```js
 let _ = values
 _= Object.keys(_)
 _= [...Array.from(new Set(_))]
@@ -350,6 +382,12 @@ return (
   </ul>
 )
 ```
+
+</td>
+</tr>
+</tbody>
+</table>
+
 </details>
 
 ## Why the Hack pipe operator

--- a/README.md
+++ b/README.md
@@ -286,6 +286,72 @@ The placeholder token of a pipeline, on the other hand, has limited scope and is
 it can be safely used in closures. While the token's value also changes based on which pipeline step
 you are looking at, you need to only scan the previous step of the pipeline to make sense of it, leading to code that is easier to read.
 
+### Pipelines are expressions
+
+Another benefit of pipelines over sequences of assignment statements (with mutable or immutable temporary variables), is that they are expressions, i.e. they resolve to a value that can be directly returned, assigned to a variable, or used in contexts such as JSX expressions. Using temporary variables, on the other hand, is based on sequences of statements, and would require an additional statement for such use.
+
+<details>
+<summary>Examples</summary>
+
+```js
+// with pipelines
+const numberedList = list |> ^.map((each, i) => `${i + 1} - ${each}`) |> ^.join('\n')
+
+// with temporary variables
+let _ = list
+    _ = _.map((each, i) => `${i + 1} - ${each}`)
+    _ = _.join('\n')
+const numberedList = _
+```
+```js
+// with pipelines
+const envVarFormat = (vars) =>
+  Object.keys(vars)
+  |> ^.map(var => `${var}=${vars[var]}`)
+  |> ^.join(' ')
+  |> chalk.dim(^, 'node', args.join(' '))
+
+// with temporary variables
+const envVarFormat = (vars) => {
+  let _ = Object.keys(vars)
+      _ = _.map(var => `${var}=${vars[var]}`)
+      _ = _.join(' ')
+      _ = chalk.dim(_, 'node', args.join(' '))
+  return _
+}
+```
+```jsx
+// with pipelines
+return (
+  <ul>
+    {
+      values
+       |> Object.keys(^)
+       |> [...Array.from(new Set(^))]
+       |> ^.map(envar => (
+        <li onClick={() => doStuff(values)}>{envar}</li>
+       ))
+    }
+  </ul>
+)
+
+// with temporary variables
+let _ = values
+_= Object.keys(_)
+_= [...Array.from(new Set(_))]
+_= _.map(envar => (
+  <li onClick={() => doStuff(values)}>{envar}</li>
+))
+const uniqKeys = _
+
+return (
+  <ul>
+    {uniqKeys}
+  </ul>
+)
+```
+</details>
+
 ## Why the Hack pipe operator
 There were **two competing proposals** for the pipe operator: Hack pipes and F# pipes.
 (Before that, there **was** a [third proposal for a “smart mix” of the first two proposals][smart mix],


### PR DESCRIPTION
As discussed in #200 , the current README only considers added value of pipelines over constant, properly named and single-use temporary variables. There is an alternative (raised in #200, #207) of using mutable variables with short names, which also achieves all of the benefits of pipelines over temporary variables currently mentioned in the README.

Example from the README, with immutable temporary variables:
```js
const envarKeys = Object.keys(envars)
const envarPairs = envarKeys.map(envar =>
  `${envar}=${envars[envar]}`);
const envarString = envarPairs.join(' ');
const consoleText = `$ ${envarString}`;
const coloredConsoleText = chalk.dim(consoleText, 'node', args.join(' '));
console.log(coloredConsoleText);
```
... which is wordy and tedious, but can be written with the pipe operator like this:
```js
envars
|> Object.keys(^)
|> ^.map(envar =>
  `${envar}=${envars[envar]}`)
|> ^.join(' ')
|> `$ ${^}`
|> chalk.dim(^, 'node', args.join(' '))
|> console.log(^);
```
... or, can be re-written using a mutable temporary variable like this:
```js
let _= envvars
_= Object.keys(_)
_= _.map(envar =>
  `${envar}=${envars[envar]}`)
_= _.join(' ')
_= `$ ${_}`
_= chalk.dim(_, 'node', args.join(' '))
_= console.log(_)
```

As discussed in #200 (see [this, as a summary of the discussion](https://github.com/tc39/proposal-pipeline-operator/issues/200#issuecomment-918468851)), benefits of pipelines over mutable temporary variables are safety and code readability. Subsequently, it would be helpful to add these additional arguments to the README itself, as the current argument against temporary variables (mentioned in the README) is incomplete (it only considers one alternative).